### PR TITLE
Feat : 게시글 내용 검색 API 구현

### DIFF
--- a/src/main/java/com/community/controller/DocumentController.java
+++ b/src/main/java/com/community/controller/DocumentController.java
@@ -4,7 +4,9 @@ import com.community.domain.dto.*;
 import com.community.service.DocumentService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -73,5 +75,16 @@ public class DocumentController {
     public ResponseEntity<SuccessResult> increaseDocumentLike(@PathVariable("document_id") String documentId) {
         documentService.increaseDocumentLike(documentId);
         return ResponseEntity.ok().body(new SuccessResult("성공", "좋아요가 성공적으로 적용 되었습니다."));
+    }
+
+    //게시글 찾기
+    @GetMapping("/document/search/{keyword}")
+    public ResponseEntity<List<FindDocumentResponse>> searchDocument(@PathVariable() String keyword,
+                                                                     @PageableDefault(size = 10)
+                                                                     @SortDefault.SortDefaults({@SortDefault(sort = "docCreateDate", direction = Sort.Direction.DESC)})
+                                                                     Pageable pageable) {
+
+        List<FindDocumentResponse> list = documentService.searchDocument(keyword,pageable);
+        return ResponseEntity.ok().body(list);
     }
 }

--- a/src/main/java/com/community/controller/DocumentController.java
+++ b/src/main/java/com/community/controller/DocumentController.java
@@ -2,6 +2,7 @@ package com.community.controller;
 
 import com.community.domain.dto.*;
 import com.community.service.DocumentService;
+import jakarta.validation.constraints.Positive;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -77,14 +78,13 @@ public class DocumentController {
         return ResponseEntity.ok().body(new SuccessResult("성공", "좋아요가 성공적으로 적용 되었습니다."));
     }
 
-    //게시글 찾기
-    @GetMapping("/document/search/{keyword}")
-    public ResponseEntity<List<FindDocumentResponse>> searchDocument(@PathVariable() String keyword,
+    //게시글 검색 조회
+    @GetMapping("/document/search/")
+    public ResponseEntity<List<FindDocumentResponse>> searchDocument(@RequestBody SearchDocumentRequest request,
                                                                      @PageableDefault(size = 10)
                                                                      @SortDefault.SortDefaults({@SortDefault(sort = "docCreateDate", direction = Sort.Direction.DESC)})
                                                                      Pageable pageable) {
-
-        List<FindDocumentResponse> list = documentService.searchDocument(keyword,pageable);
+        List<FindDocumentResponse> list = documentService.searchDocument(request.getKeyword(),pageable);
         return ResponseEntity.ok().body(list);
     }
 }

--- a/src/main/java/com/community/domain/dto/SearchDocumentRequest.java
+++ b/src/main/java/com/community/domain/dto/SearchDocumentRequest.java
@@ -1,0 +1,12 @@
+package com.community.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SearchDocumentRequest {
+    private String keyword;
+}

--- a/src/main/java/com/community/repository/DocumentRepository.java
+++ b/src/main/java/com/community/repository/DocumentRepository.java
@@ -15,5 +15,5 @@ import java.util.*;
 public interface DocumentRepository extends JpaRepository<Document, String> {
     Optional<List<Document>> findAllByDocCreator(Member member);
     Slice<Document> findAllByBoard(Board board, Pageable page);
-
+    Slice<Document> findByDocContentContaining(String keyword, Pageable page);
 }

--- a/src/main/java/com/community/service/DocumentService.java
+++ b/src/main/java/com/community/service/DocumentService.java
@@ -152,6 +152,9 @@ public class DocumentService {
 
     @Transactional
     public List<FindDocumentResponse> searchDocument(String keyword, Pageable pageable) {
+        if (keyword == null) {
+            throw new IllegalArgumentException("잘못된 입력 입니다.");
+        }
         Slice<Document> slice = documentRepository.findByDocContentContaining(keyword,pageable);
 
         List<Document> list = slice.getContent();

--- a/src/main/java/com/community/service/DocumentService.java
+++ b/src/main/java/com/community/service/DocumentService.java
@@ -149,4 +149,23 @@ public class DocumentService {
         likeItRepository.updateLikeCount(count, document.getDocId());
         return new DocumentWriteResponse(document);
     }
+
+    @Transactional
+    public List<FindDocumentResponse> searchDocument(String keyword, Pageable pageable) {
+        Slice<Document> slice = documentRepository.findByDocContentContaining(keyword,pageable);
+
+        List<Document> list = slice.getContent();
+        List<FindDocumentResponse> resultList = new ArrayList<>();
+
+        for (Document document : list) {
+            if (!document.getDocVisible()) continue;
+            Long viewCount = viewershipRepository.findById(document.getDocId()).get().getViewCount() + 1L;
+            Long likeCount = likeItRepository.findById(document.getDocId()).get().getLikeCount();
+
+            viewershipRepository.updateViewership(viewCount, document.getDocId());
+
+            resultList.add(new FindDocumentResponse(document, viewCount, likeCount));
+        }
+        return resultList;
+    }
 }


### PR DESCRIPTION
게시판을 구분하지 않고 게시글 내용을 검색할 수 있는 API 구현


- parameter에서 request body로 변경(null, 빈칸 시 오류 예방)


resolved : #126